### PR TITLE
Make individual round trip tests async

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,5 @@ jobs:
       - name: Build the project
         run: npm run build
 
-      - name: Build and bundle tests
-        run: spago bundle-module --main Test.Main --to output/index.js && ./node_modules/@vercel/ncc/dist/ncc/cli.js build --minify test/index.js
-
       - name: Run tests
-        uses: ./test
-        with:
-          testinput: test
+        run: spago test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Changed
+- Made test runners async within each type of round trip [#2](https://github.com/jisantuc/purescript-turf/pull/2) (@jisantuc)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "eslint src && spago build --purs-args --censor-lib --strict --censor-codes=UserDefinedWarning",
+    "build": "spago build --purs-args '--censor-lib --strict --censor-codes=UserDefinedWarning'",
     "test": "spago test --no-install"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,6 @@
     "build": "spago build --purs-args '--censor-lib --strict --censor-codes=UserDefinedWarning'",
     "test": "spago test --no-install"
   },
-  "devDependencies": {
-    "@vercel/ncc": "^0.24.1",
-    "eslint": "^7.6.0"
-  },
   "dependencies": {
     "@turf/helpers": "^6.3.0"
   }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -6,7 +6,7 @@ import Data.Either (Either(..))
 import Effect (Effect)
 import Effect.Class (liftEffect)
 import Foreign.Object (empty)
-import Prelude (class Show, class Eq, ($), (<>), (<$>), (==), discard, show, Unit)
+import Prelude (class Eq, class Show, Unit, apply, discard, map, show, unit, ($), (<$>), (<>), (==))
 import Test.QuickCheck (Result, quickCheck, (<?>))
 import Test.Unit (suite, test)
 import Test.Unit.Main (runTest)
@@ -15,20 +15,26 @@ import Turf.Helpers (Feature, FeatureProperties, LineStringFeature, LineStringGe
 main :: Effect Unit
 main =
   runTest do
-    suite "Codec round trips" do
-      test "PointGeom" $ liftEffect $ quickCheck (\(x :: PointGeom) -> codecRoundTrip x)
-      test "PointFeature" $ liftEffect $ quickCheck (\(x :: PointFeature) -> codecRoundTrip x)
-      test "MultiPointGeom" $ liftEffect $ quickCheck (\(x :: MultiPointGeom) -> codecRoundTrip x)
-      test "MultiPointFeature" $ liftEffect $ quickCheck (\(x :: MultiPointFeature) -> codecRoundTrip x)
-      test "LineStringGeom" $ liftEffect $ quickCheck (\(x :: LineStringGeom) -> codecRoundTrip x)
-      test "LineStringFeature" $ liftEffect $ quickCheck (\(x :: LineStringFeature) -> codecRoundTrip x)
-      test "MultiLineStringGeom" $ liftEffect $ quickCheck (\(x :: MultiLineStringGeom) -> codecRoundTrip x)
-      test "MultiLineStringFeature" $ liftEffect $ quickCheck (\(x :: MultiLineStringFeature) -> codecRoundTrip x)
-    suite "JavaScript round trips" do
-      test "Construct a point" $ liftEffect $ quickCheck (\(x :: PointGeom) -> jsRoundTrip x point)
-      test "Construct a multipoint" $ liftEffect $ quickCheck (\(x :: MultiPointGeom) -> jsRoundTrip x multiPoint)
-      test "Construct a linestring" $ liftEffect $ quickCheck (\(x :: LineStringGeom) -> jsRoundTrip x lineString)
-      test "Construct a multilinestring" $ liftEffect $ quickCheck (\(x :: MultiLineStringGeom) -> jsRoundTrip x multiLineString)
+    suite "Round trips" do
+      test "JSON codecs" $ liftEffect
+        $ ado
+            quickCheck (\(x :: PointGeom) -> codecRoundTrip x)
+            quickCheck (\(x :: PointFeature) -> codecRoundTrip x)
+            quickCheck (\(x :: MultiPointGeom) -> codecRoundTrip x)
+            quickCheck (\(x :: MultiPointFeature) -> codecRoundTrip x)
+            quickCheck (\(x :: LineStringGeom) -> codecRoundTrip x)
+            quickCheck (\(x :: LineStringFeature) -> codecRoundTrip x)
+            quickCheck (\(x :: MultiLineStringGeom) -> codecRoundTrip x)
+            quickCheck (\(x :: MultiLineStringFeature) -> codecRoundTrip x)
+            in unit
+      test "JavaScript FFI calls"
+        $ liftEffect
+        $ ado
+            quickCheck (\(x :: PointGeom) -> jsRoundTrip x point)
+            quickCheck (\(x :: MultiPointGeom) -> jsRoundTrip x multiPoint)
+            quickCheck (\(x :: LineStringGeom) -> jsRoundTrip x lineString)
+            quickCheck (\(x :: MultiLineStringGeom) -> jsRoundTrip x multiLineString)
+            in unit
 
 jsRoundTrip :: forall a. Eq a => Show a => EncodeJson a => a -> (a -> FeatureProperties -> Either JsonDecodeError (Feature a)) -> Result
 jsRoundTrip geom f =


### PR DESCRIPTION
Overview
-----

This PR changes test execution so that instead of having tons of `test "foo" $ liftEffect $ quickCheck ...` lines, there's a single `test "foo" $ liftEffect`, then all the property tests can run on their own. 

Notes
-----

The downside seems to be only reporting the first failed test? I'm not sure that's a great trade, but it makes tests a lot faster, so it's probably still worth it.