### PR TITLE
Dependency lint for 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Upgraded package set to 0.14.0 [#7](https://github.com/jisantuc/purescript-turf/pull/7) (@jisantuc)
 
+### Removed
+- Removed `test-unit` dependency [#8](https://github.com/jisantuc/purescript-turf/pull/8) (@jisantuc)
+
 ## [0.1.1] - 2021-02-28
 ### Changed
 - Upgraded package-set to latest 0.13.8 set [#6](https://github.com/jisantuc/purescript-turf/pull/6) (@jisantuc)

--- a/bower.json
+++ b/bower.json
@@ -14,14 +14,14 @@
         "output"
     ],
     "dependencies": {
-        "purescript-argonaut-codecs": "^v7.0.0",
-        "purescript-argonaut-core": "^v5.1.0",
-        "purescript-assert": "^v4.1.0",
-        "purescript-console": "^v4.4.0",
-        "purescript-effect": "^v2.0.1",
-        "purescript-foreign-object": "^v2.0.3",
-        "purescript-psci-support": "^v4.0.0",
-        "purescript-quickcheck": "^v6.1.0",
+        "purescript-argonaut-codecs": "^v8.0.0",
+        "purescript-argonaut-core": "^v6.0.0",
+        "purescript-assert": "^v5.0.0",
+        "purescript-console": "^v5.0.0",
+        "purescript-effect": "^v3.0.0",
+        "purescript-foreign-object": "^v3.0.0",
+        "purescript-psci-support": "^v5.0.0",
+        "purescript-quickcheck": "^v7.0.0",
         "purescript-test-unit": "^v15.0.0"
     }
 }

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,6 @@
         "purescript-effect": "^v3.0.0",
         "purescript-foreign-object": "^v3.0.0",
         "purescript-psci-support": "^v5.0.0",
-        "purescript-quickcheck": "^v7.0.0",
-        "purescript-test-unit": "^v15.0.0"
+        "purescript-quickcheck": "^v7.0.0"
     }
 }

--- a/spago.dhall
+++ b/spago.dhall
@@ -12,7 +12,6 @@ You can edit this file as you like.
   , "foreign-object"
   , "psci-support"
   , "quickcheck"
-  , "test-unit"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,25 +4,9 @@ import Data.Argonaut.Decode (class DecodeJson, JsonDecodeError, decodeJson)
 import Data.Argonaut.Encode (class EncodeJson, encodeJson)
 import Data.Either (Either(..))
 import Effect (Effect)
-import Effect.Class (liftEffect)
 import Foreign.Object (empty)
-import Prelude
-  ( class Eq
-  , class Show
-  , Unit
-  , apply
-  , discard
-  , map
-  , show
-  , unit
-  , ($)
-  , (<$>)
-  , (<>)
-  , (==)
-  )
+import Prelude (class Eq, class Show, Unit, apply, map, show, unit, (<$>), (<>), (==))
 import Test.QuickCheck (Result, quickCheck, (<?>))
-import Test.Unit (suite, test)
-import Test.Unit.Main (runTest)
 import Turf.Helpers
   ( Feature
   , FeatureProperties
@@ -48,47 +32,39 @@ import Turf.Helpers
   )
 
 main :: Effect Unit
-main =
-  runTest do
-    suite "Round trips" do
-      test "JSON codecs" $ liftEffect
-        $ ado
-            quickCheck (\(x :: PointGeom) -> codecRoundTrip x)
-            quickCheck (\(x :: PointFeature) -> codecRoundTrip x)
-            quickCheck (\(x :: MultiPointGeom) -> codecRoundTrip x)
-            quickCheck (\(x :: MultiPointFeature) -> codecRoundTrip x)
-            quickCheck (\(x :: LineStringGeom) -> codecRoundTrip x)
-            quickCheck (\(x :: LineStringFeature) -> codecRoundTrip x)
-            quickCheck (\(x :: MultiLineStringGeom) -> codecRoundTrip x)
-            quickCheck (\(x :: MultiLineStringFeature) -> codecRoundTrip x)
-            quickCheck (\(x :: PolygonGeom) -> codecRoundTrip x)
-            quickCheck (\(x :: PolygonFeature) -> codecRoundTrip x)
-            quickCheck (\(x :: MultiPolygonGeom) -> codecRoundTrip x)
-            quickCheck (\(x :: MultiPolygonFeature) -> codecRoundTrip x)
-            in unit
-      test "JavaScript FFI calls"
-        $ liftEffect
-        $ ado
-            quickCheck (\(x :: PointGeom) -> jsRoundTrip x point)
-            quickCheck (\(x :: MultiPointGeom) -> jsRoundTrip x multiPoint)
-            quickCheck (\(x :: LineStringGeom) -> jsRoundTrip x lineString)
-            quickCheck (\(x :: MultiLineStringGeom) -> jsRoundTrip x multiLineString)
-            quickCheck (\(x :: PolygonGeom) -> jsRoundTrip x polygon)
-            quickCheck (\(x :: MultiPolygonGeom) -> jsRoundTrip x multiPolygon)
-            in unit
+main = ado
+  quickCheck (\(x :: PointGeom) -> codecRoundTrip "PointGeom codec" x)
+  quickCheck (\(x :: PointFeature) -> codecRoundTrip "PointFeature codec" x)
+  quickCheck (\(x :: MultiPointGeom) -> codecRoundTrip "MultiPointGeom codec" x)
+  quickCheck (\(x :: MultiPointFeature) -> codecRoundTrip "MultiPointFeature codec" x)
+  quickCheck (\(x :: LineStringGeom) -> codecRoundTrip "LineStringGeom codec" x)
+  quickCheck (\(x :: LineStringFeature) -> codecRoundTrip "LineStringFeature codec" x)
+  quickCheck (\(x :: MultiLineStringGeom) -> codecRoundTrip "MultiLineStringGeom codec" x)
+  quickCheck (\(x :: MultiLineStringFeature) -> codecRoundTrip "MultiLineStringFeature codec" x)
+  quickCheck (\(x :: PolygonGeom) -> codecRoundTrip "PolygonGeom codec" x)
+  quickCheck (\(x :: PolygonFeature) -> codecRoundTrip "PolygonFeature codec" x)
+  quickCheck (\(x :: MultiPolygonGeom) -> codecRoundTrip "MultiPolygonGeom codec" x)
+  quickCheck (\(x :: MultiPolygonFeature) -> codecRoundTrip "MultiPolygonFeature codec" x)
+  quickCheck (\(x :: PointGeom) -> jsRoundTrip "point FFI" x point)
+  quickCheck (\(x :: MultiPointGeom) -> jsRoundTrip "multipoint FFI" x multiPoint)
+  quickCheck (\(x :: LineStringGeom) -> jsRoundTrip "lineString FFI" x lineString)
+  quickCheck (\(x :: MultiLineStringGeom) -> jsRoundTrip "multiLineString FFI" x multiLineString)
+  quickCheck (\(x :: PolygonGeom) -> jsRoundTrip "polygon FFI" x polygon)
+  quickCheck (\(x :: MultiPolygonGeom) -> jsRoundTrip "multiPolygon FFI" x multiPolygon)
+  in unit
 
-jsRoundTrip :: forall a. Eq a => Show a => EncodeJson a => a -> (a -> FeatureProperties -> Either JsonDecodeError (Feature a)) -> Result
-jsRoundTrip geom f =
+jsRoundTrip :: forall a. Eq a => Show a => EncodeJson a => String -> a -> (a -> FeatureProperties -> Either JsonDecodeError (Feature a)) -> Result
+jsRoundTrip tag geom f =
   let
     result = f geom empty
   in
-    (featureGeometry <$> result) == Right geom <?> "Result: \n" <> show result <> "\nnot equal to expected:\n" <> show geom
+    (featureGeometry <$> result) == Right geom <?> "Test: " <> tag <> ". Result: \n" <> show result <> "\nnot equal to expected:\n" <> show geom
 
-codecRoundTrip :: forall a. Eq a => Show a => DecodeJson a => EncodeJson a => a -> Result
-codecRoundTrip a =
+codecRoundTrip :: forall a. Eq a => Show a => DecodeJson a => EncodeJson a => String -> a -> Result
+codecRoundTrip tag a =
   let
     encoded = encodeJson a
 
     decoded = decodeJson encoded
   in
-    decoded == Right a <?> "Result: \n" <> show decoded <> "\nnot equal to expected:\n" <> show a
+    decoded == Right a <?> "Test: " <> tag <> ". Result: \n" <> show decoded <> "\nnot equal to expected:\n" <> show a


### PR DESCRIPTION
`test-unit` in the package set has some old deps, and also I'm not really using anything from it, so it's _gone_. This resolves an error where the `Data.Generic.Rep` module is declared twice, preventing `pulp publish` from running successfully.